### PR TITLE
Add Parselmouth to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ The aim of this repository is to create a comprehensive, curated list of python 
 
 ## Audio Related Packages
 
-- Total number of packages: 71
-- Python version compatibility:  ![69](http://progressed.io/bar/99?title=python%202) ![61](http://progressed.io/bar/85?title=python%203)
+- Total number of packages: 72
+- Python version compatibility:  ![70](http://progressed.io/bar/99?title=python%202) ![62](http://progressed.io/bar/85?title=python%203)
 
 #### Read-Write
 
@@ -77,6 +77,7 @@ The aim of this repository is to create a comprehensive, curated list of python 
 #### Speech Processing
 
 * [aeneas](https://www.readbeyond.it/aeneas/) [:octocat:](https://github.com/readbeyond/aeneas/) [:package:](https://pypi.python.org/pypi/aeneas/) - Forced aligner, based on MFCC+DTW, 35+ languages.
+* [Parselmouth](https://github.com/YannickJadoul/Parselmouth) [:octocat:](https://github.com/YannickJadoul/Parselmouth) [:package:](https://pypi.org/project/praat-parselmouth/) - Python interface to the [Praat](http://www.praat.org) phonetics and speech analysis, synthesis, and manipulation software.
 * [pyAudioAnalysis](https://github.com/tyiannak/pyAudioAnalysis)² [:octocat:](https://github.com/tyiannak/pyAudioAnalysis) [:package:](https://pypi.python.org/pypi/pyAudioAnalysis/) - Feature Extraction, Classification, Diarization.
 * [py-webrtcvad](https://github.com/wiseman/py-webrtcvad) [:octocat:](https://github.com/wiseman/py-webrtcvad) [:package:](https://pypi.python.org/pypi/webrtcvad/) -  Interface to the WebRTC Voice Activity Detector.
 * [PyWorldVocoder](https://github.com/JeremyCCHsu/Python-Wrapper-for-World-Vocoder) [:octocat:](https://github.com/JeremyCCHsu/Python-Wrapper-for-World-Vocoder) - Wrapper for Morise's World Vocoder.


### PR DESCRIPTION
As described, Parselmouth is a Python interface to the widely-used scientific Praat software (cfr. [Google Scholar's list of Praat citations](https://scholar.google.com/scholar?cites=8104635033638065008&as_sdt=2005&sciodt=0,5&hl=en)).

Not entirely sure this is the correct section/category, given the range of Praat's functionality, but I think it fits best under "Speech Processing" ?