### PR TITLE
Add demucs-onnx to Source Separation

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ The aim of this repository is to create a comprehensive, curated list of python 
 #### Source Separation
 
 * [commonfate](https://github.com/aliutkus/commonfate) [:octocat:](https://github.com/aliutkus/commonfate) [:package:](https://pypi.python.org/pypi/commonfate) - Common Fate Model and Transform.
+* [demucs-onnx](https://stemsplit.github.io/demucs-onnx/) [:octocat:](https://github.com/StemSplit/demucs-onnx) [:package:](https://pypi.org/project/demucs-onnx/) - HT-Demucs music source separation as ONNX, with pure numpy + onnxruntime at inference and an exporter that handles the four torch.onnx.export blockers.
 * [NTFLib](https://github.com/stitchfix/NTFLib) [:octocat:](https://github.com/stitchfix/NTFLib) - Sparse Beta-Divergence Tensor Factorization.
 * [NUSSL](https://interactiveaudiolab.github.io/project/nussl.html) [:octocat:](https://github.com/interactiveaudiolab/nussl) [:package:](https://pypi.python.org/pypi/nussl) - Holistic source separation framework including DSP methods and deep learning methods.
 * [NIMFA](http://nimfa.biolab.si) [:octocat:](https://github.com/marinkaz/nimfa) [:package:](https://pypi.python.org/pypi/nimfa) - Several flavors of non-negative-matrix factorization.


### PR DESCRIPTION
Add `demucs-onnx` to the Source Separation section.

### Why it fits

The Source Separation section currently has four entries (commonfate, NTFLib, NUSSL, NIMFA) — all NMF/matrix-factorization toolkits, none cover the modern deep-learning source separation models that have dominated MIR since ~2019.

`demucs-onnx` is a pip-installable Python package that runs Meta's HT-Demucs (the architecture behind `facebookresearch/demucs`, the open-source baseline most papers compare against) as ONNX, with no PyTorch needed at inference. It also ships an export pipeline that patches the four `torch.onnx.export` blockers that have left three multi-year-open issues unanswered on the upstream demucs repo (#281, #530, #539). MIT licensed; pre-built models for the htdemucs_ft 4-stem bag and htdemucs_6s 6-stem variant are mirrored on the HF Hub.

### Awesome criteria

- Audio/music related — yes (music source separation).
- Open source license — yes, MIT.
- Useful for several fields — used for MIR research (stem datasets, vocal extraction for ASR/transcription pipelines), audio plugin development (cross-platform via onnxruntime EPs incl. CoreML / DirectML / CUDA), and browser-side inference (onnxruntime-web).
- Listed on PyPI — yes ([demucs-onnx](https://pypi.org/project/demucs-onnx/)).
- Version controlled — yes ([StemSplit/demucs-onnx](https://github.com/StemSplit/demucs-onnx)).
- Python 3 — yes.

### Entry

Added between `commonfate` and `NTFLib`:

```
* [demucs-onnx](https://stemsplit.github.io/demucs-onnx/) [:octocat:](https://github.com/StemSplit/demucs-onnx) [:package:](https://pypi.org/project/demucs-onnx/) - HT-Demucs music source separation as ONNX, with pure numpy + onnxruntime at inference and an exporter that handles the four torch.onnx.export blockers.
```

Happy to adjust phrasing, position, or scope to match house style.

Made with [Cursor](https://cursor.com)