### PR TITLE
Add visqol-python

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ The aim of this repository is to create a comprehensive, curated list of python 
 * [py-webrtcvad](https://github.com/wiseman/py-webrtcvad) [:octocat:](https://github.com/wiseman/py-webrtcvad) [:package:](https://pypi.python.org/pypi/webrtcvad/) -  Interface to the WebRTC Voice Activity Detector.
 * [pypesq](https://github.com/vBaiCai/python-pesq) [:octocat:](https://github.com/vBaiCai/python-pesq) - Wrapper for the PESQ score calculation.
 * [pystoi](https://github.com/mpariente/pystoi) [:octocat:](https://github.com/mpariente/pystoi) [:package:](https://pypi.org/project/pystoi) - Short Term Objective Intelligibility measure (STOI).
+* [visqol-python](https://github.com/talker93/visqol-python) [:octocat:](https://github.com/talker93/visqol-python) [:package:](https://pypi.org/project/visqol-python/) - Port of Google's ViSQOL audio/speech quality metric (MOS-LQO) that installs without Bazel.
 * [PyWorldVocoder](https://github.com/JeremyCCHsu/Python-Wrapper-for-World-Vocoder) [:octocat:](https://github.com/JeremyCCHsu/Python-Wrapper-for-World-Vocoder) - Wrapper for Morise's World Vocoder.
 * [Montreal Forced Aligner](https://montrealcorpustools.github.io/Montreal-Forced-Aligner/) [:octocat:](https://github.com/MontrealCorpusTools/Montreal-Forced-Aligner) - Forced aligner, based on Kaldi (HMM), English (others can be trained).
 * [SIDEKIT](http://lium.univ-lemans.fr/sidekit/) [:package:](https://pypi.python.org/pypi/SIDEKIT/) - Speaker and Language recognition.


### PR DESCRIPTION
Adds [visqol-python](https://github.com/talker93/visqol-python), a port of [Google's ViSQOL](https://github.com/google/visqol) (objective audio/speech quality metric, MOS-LQO scale 1–5) that installs from PyPI without Bazel.

Why awesome:
- Useful across several research fields: audio codec eval, speech enhancement, VoIP/telephony, generative audio (e.g. AudioCraft METRICS already use ViSQOL).
- Bit-near parity with the C++ binary: audio conformance ≤ 0.0001 MOS diff (10/10 cases), speech polynomial 0.001, speech lattice 0.002.
- Optional `[lattice]` extra runs the same TFLite deep-lattice quality mapper as `./bazel-bin/visqol --use_lattice_model=true` (the C++ default), via Google's `ai-edge-litert`.
- Optional Numba acceleration gets RTF down to ~0.064 (~9× over scipy).
- Apache-2.0; CI on Python 3.9–3.13 × NumPy 1.x/2.x.

Inserted alongside the existing `pypesq` / `pystoi` entries — these are the three commonly used objective speech-quality metrics.

Re-read the contributing guidelines:
- ✅ audio/music related (objective quality metric)
- ✅ open source license that allows contributions (Apache-2.0)
- ✅ useful for several fields (codec eval / VoIP / speech enhancement / generative audio)
- ✅ listed on PyPI (📦 link included)
- ✅ open development on GitHub
- ✅ Python 3 only